### PR TITLE
Replace prefix and exchange settings by virtual host.

### DIFF
--- a/app/jobs/indexing_job.rb
+++ b/app/jobs/indexing_job.rb
@@ -2,7 +2,7 @@
 
 # Post-processes a finished job that was sent to Hets
 class IndexingJob < ApplicationJob
-  queue_as "#{Settings.rabbitmq.prefix}_indexing"
+  queue_as 'indexing'
   ALLOWED_INDEXERS = [RepositoryIndexer,
                       UserIndexer,
                       OrganizationIndexer].map(&:to_s)

--- a/app/workers/indexing_worker.rb
+++ b/app/workers/indexing_worker.rb
@@ -2,6 +2,5 @@
 
 # Worker for indexing the data
 class IndexingWorker < ApplicationWorker
-  from_queue "#{Settings.rabbitmq.prefix}_indexing",
-    threads: 1, prefetch: 1, timeout_job_after: nil
+  from_queue 'indexing', threads: 1, prefetch: 1, timeout_job_after: nil
 end

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -4,11 +4,13 @@ if Rails.env.test?
   Sneakers.configure(connection: BunnyMock.new)
 else
   # :nocov:
-  Sneakers.configure(connection: Bunny.new(username: Settings.rabbitmq.username,
-                                           password: Settings.rabbitmq.password,
-                                           host: Settings.rabbitmq.host,
-                                           port: Settings.rabbitmq.port),
-                     exchange: Settings.rabbitmq.exchange)
+  Sneakers.
+    configure(connection:
+              Bunny.new(username: Settings.rabbitmq.username,
+                        password: Settings.rabbitmq.password,
+                        host: Settings.rabbitmq.host,
+                        port: Settings.rabbitmq.port,
+                        virtual_host: Settings.rabbitmq.virtual_host))
   Sneakers.logger.level = Logger::WARN
   # :nocov:
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,5 +3,4 @@ rabbitmq:
   port: 5672
   username: guest
   password: guest
-  prefix: ontohub
-  exchange: ontohub
+  virtual_host: ontohub_development

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,2 @@
+rabbitmq:
+  virtual_host: ontohub

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,5 +3,4 @@ rabbitmq:
   port: 25672
   username: tester
   password: testing
-  prefix: indexer_test
-  exchange: indexer_test
+  virtual_host: indexer_test


### PR DESCRIPTION
This simplifies the configuration of rabbitmq. However, this does not solve the actual problem that jobs can't be published (causing a timeout).